### PR TITLE
Releases/ricardo

### DIFF
--- a/backend/realtime-service/chat/consumers.py
+++ b/backend/realtime-service/chat/consumers.py
@@ -39,3 +39,32 @@ class ChatConsumer(AsyncWebsocketConsumer):
                 'content': content,
             }
         )
+
+    async def chat_message(self, event):
+        await self.send(text_data=json.dumps({
+            'sender_id': event['sender_id'],
+            'content': event['content'],
+        }))
+
+    @database_sync_to_async
+    def save_message(self, recipient_id, content):
+        Message.objects.create(
+            sender_id=self.user_id,
+            recipient_id=recipient_id,
+            content=content
+        )
+
+    @database_sync_to_async
+    def update_online_status(self, status):
+        from django.db import connection
+        with connection.cursor() as cursor:
+            if status:
+                cursor.execute(
+                    'UPDATE "user" SET online_status = %s, WHERE user_id = %s',
+                    [True, self.user_id]
+                )
+            else:
+                cursor.execute(
+                    'UPDATE "user" SET online_status = %s, last_seen = %s WHERE user_id = %s',
+                    [False, timezone.now(), self.user_id]
+                )

--- a/backend/realtime-service/chat/consumers.py
+++ b/backend/realtime-service/chat/consumers.py
@@ -6,7 +6,16 @@ from .models import Message
 
 class ChatConsumer(AsyncWebsocketConsumer):
     async def connect(self):
+        self.user_id = self.scope['url_route']['kwargs']['user_id']
+        self.room_group_name = f'chat_{self.user_id}'
+
+        await self.channel_layer.group_add(
+            self.room_group_name,
+            self.channel_name
+        )
+
         await self.accept()
+        await self.update_online_status(True)
 
     async def disconnect(self, close_code):
         pass

--- a/backend/realtime-service/chat/consumers.py
+++ b/backend/realtime-service/chat/consumers.py
@@ -18,7 +18,11 @@ class ChatConsumer(AsyncWebsocketConsumer):
         await self.update_online_status(True)
 
     async def disconnect(self, close_code):
-        pass
+        await self.channel_layer.group_discard(
+            self.room_group_name,
+            self.channel_name
+        )
+        await self.update_online_status(False)
 
     async def receive(self, text_data):
         await self.send(text_data=text_data)

--- a/backend/realtime-service/chat/consumers.py
+++ b/backend/realtime-service/chat/consumers.py
@@ -1,5 +1,8 @@
 import json
 from channels.generic.websocket import AsyncWebsocketConsumer
+from channels.db import database_sync_to_async
+from django.utils import timezone
+from .models import Message
 
 class ChatConsumer(AsyncWebsocketConsumer):
     async def connect(self):

--- a/backend/realtime-service/chat/consumers.py
+++ b/backend/realtime-service/chat/consumers.py
@@ -25,4 +25,17 @@ class ChatConsumer(AsyncWebsocketConsumer):
         await self.update_online_status(False)
 
     async def receive(self, text_data):
-        await self.send(text_data=text_data)
+        data = json.loads(text_data)
+        recipient_id = data['recipient_id']
+        content = data['content']
+
+        await self.save_message(recipient_id, content)
+
+        await self.channel_layer.group_send(
+            f'chat_{recipient_id}',
+            {
+                'type': 'chat_message',
+                'sender_id': self.user_id,
+                'content': content,
+            }
+        )

--- a/backend/realtime-service/chat/routing.py
+++ b/backend/realtime-service/chat/routing.py
@@ -2,5 +2,5 @@ from django.urls import re_path
 from . import consumers
 
 websocket_urlpatterns = [
-        re_path(r'ws/chat/(?P<user_id>\d+)/$', consumers.ChatConsumer.as_alive_group),
+        re_path(r'ws/chat/(?P<user_id>\d+)/$', consumers.ChatConsumer.as_asgi()),
 ]

--- a/backend/realtime-service/core/settings.py
+++ b/backend/realtime-service/core/settings.py
@@ -82,8 +82,8 @@ DATABASES = {
         'NAME': os.environ.get('POSTGRES_DB'),
         'USER': os.environ.get('POSTGRES_USER'),
         'PASSWORD': os.environ.get('POSTGRES_PASSWORD'),
-        'HOST': os.environ.get('POSTGRES_HOST', 'postgres'),
-        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
+        'HOST': os.environ.get('POSTGRES_HOST'),
+        'PORT': os.environ.get('POSTGRES_PORT'),
     }
 }
 


### PR DESCRIPTION
Closes #74 

Implement the WebSocket chat consumer and routing for realtime-service.

- edit `chat/consumers.py`
- `connect`: accepts connection, joins user's channel group, sets online_status = true
- `disconnect`: leaves channel group, sets online_status = false, records last_seen
- `receive`: saves message to DB, broadcasts to recipient's channel group
- `chat/routing.py` — fixed `as_alive_group` to `as_asgi`