### PR TITLE
feat: REST endpoint for chat message history

### DIFF
--- a/realtime-service/chat/urls.py
+++ b/realtime-service/chat/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path('chat/messages/<int:user_id>/', views.message_history, name='message-history'),
+]

--- a/realtime-service/chat/views.py
+++ b/realtime-service/chat/views.py
@@ -1,3 +1,33 @@
-from django.shortcuts import render
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from rest_framework import status
+from .models import Message
+from django.db.models import Q
 
-# Create your views here.
+@api_view(['GET'])
+def message_history(request, user_id):
+    logged_in_user = request.query_params.get('sender_id')
+
+    if not logged_in_user:
+        return Response(
+            {'error': 'sender_id is required'},
+            status=status.HTTP_400_BAD_REQUEST
+        )
+    messages = Message.objects.filter(
+        Q(sender_id=logged_in_user, recipient_id=user_id) |
+        Q(sender_id=user_id, recipient_id=logged_in_user)
+    ).order_by('created_at')[:50]
+
+    data = [
+        {
+            'id': m.id,
+            'sender_id': m.sender_id,
+            'recipient_id': m.recipient_id,
+            'content': m.content,
+            'read_at': m.read_at,
+            'created_at': m.created_at,
+        }
+        for m in messages
+    ]
+
+    return Response(data, status=status.HTTP_200_OK)

--- a/realtime-service/core/asgi.py
+++ b/realtime-service/core/asgi.py
@@ -8,16 +8,17 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 """
 
 import os
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
 
 from django.core.asgi import get_asgi_application
+django_asgi_app = get_asgi_application()
+    
 from channels.routing import ProtocolTypeRouter, URLRouter
 from channels.auth import AuthMiddlewareStack
 import chat.routing
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'core.settings')
-
 application = ProtocolTypeRouter({
-    "http": get_asgi_application(),
+    "http": django_asgi_app,
     "websocket": AuthMiddlewareStack(
         URLRouter(
             chat.routing.websocket_urlpatterns

--- a/realtime-service/core/settings.py
+++ b/realtime-service/core/settings.py
@@ -38,6 +38,7 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
     'channels',
     'chat',
     'notifications',

--- a/realtime-service/core/urls.py
+++ b/realtime-service/core/urls.py
@@ -15,8 +15,9 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('', include('chat.urls')),
 ]

--- a/realtime-service/requirements.txt
+++ b/realtime-service/requirements.txt
@@ -3,3 +3,4 @@ channels>=4.0
 channels-redis>=4.0
 daphne>=4.0
 psycopg2-binary>=2.9
+djangorestframework>=3.14


### PR DESCRIPTION
Closes #85 

REST endpoint to fetch conversation history between two users.

`GET /chat/messages/{user_id}/?sender_id={logged_in_user_id}`

Can be tested running:
`curl "http://localhost:8001/chat/messages/1/?sender_id=2"`

It should return an empty list `[]`